### PR TITLE
fix ProcessTimedOutException

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -33,5 +33,6 @@ RUN set -eux && \
   docker-php-ext-enable xdebug && \
   mkdir $PSYSH_DIR && wget $PHP_MANUAL_URL -P $PSYSH_DIR && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+  composer config -g process-timeout 3600 && \
   composer config -g repos.packagist composer https://packagist.jp && \
   composer global require hirak/prestissimo


### PR DESCRIPTION
<img width="894" alt="スクリーンショット 2019-12-08 22 20 08" src="https://user-images.githubusercontent.com/35098175/70389899-ed35ad80-1a08-11ea-86d6-262fe649c56b.png">


```
$ make create-project
...

  [Symfony\Component\Process\Exception\ProcessTimedOutException]
  The process "'/usr/local/bin/php' -d allow_url_fopen='1' -d disable_functio
  ns='' -d memory_limit='-1' artisan package:discover --ansi" exceeded the ti
  meout of 300 seconds.


create-project [-s|--stability STABILITY] [--prefer-source] [--prefer-dist] [--repository REPOSITORY] [--repository-url REPOSITORY-URL] [--dev] [--no-dev] [--no-custom-installers] [--no-scripts] [--no-progress] [--no-secure-http] [--keep-vcs] [--remove-vcs] [--no-install] [--ignore-platform-reqs] [--] [<package>] [<directory>] [<version>]

make: *** [create-project] Error 1
```
