### PR TITLE
Fix hadolint

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -17,16 +17,16 @@ ENV COMPOSER_HOME /composer
 
 RUN apk update && \
   apk add --update --no-cache --virtual=.build-dependencies \
-    autoconf \
-    gcc \
-    g++ \
-    make \
-    tzdata \
-    git && \
+    autoconf=~2.69 \
+    gcc=~9.2 \
+    g++=~9.2 \
+    make=~4.2 \
+    tzdata=2019c-r0 \
+    git=~2.24 && \
   apk add --update --no-cache \
-    icu-dev \
-    libzip-dev \
-    oniguruma-dev && \
+    icu-dev=~64.2 \
+    libzip-dev=~1.5 \
+    oniguruma-dev=~6.9 && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo ${TZ} > /etc/timezone && \
   pecl install xdebug && \

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,6 +1,8 @@
 FROM php:7.4-fpm-alpine
 LABEL maintainer="ucan-lab <info@u-can.tech>"
 
+SHELL ["/bin/ash", "-oeux", "pipefail", "-c"]
+
 # tinker(psysh)
 ARG PSYSH_DIR=/usr/local/share/psysh
 ARG PHP_MANUAL_URL=http://psysh.org/manual/ja/php_manual.sqlite
@@ -12,8 +14,7 @@ ARG TZ
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /composer
 
-RUN set -eux && \
-  apk update && \
+RUN apk update && \
   apk add --update --no-cache --virtual=.build-dependencies \
     autoconf \
     gcc \

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -5,6 +5,7 @@ SHELL ["/bin/ash", "-oeux", "pipefail", "-c"]
 
 # tinker(psysh)
 ARG PSYSH_DIR=/usr/local/share/psysh
+ARG PSYSH_PHP_MANUAL=$PSYSH_DIR/php_manual.sqlite
 ARG PHP_MANUAL_URL=http://psysh.org/manual/ja/php_manual.sqlite
 
 # timezone
@@ -33,7 +34,7 @@ RUN apk update && \
   apk del .build-dependencies && \
   docker-php-ext-install intl pdo_mysql mbstring zip bcmath redis && \
   docker-php-ext-enable xdebug && \
-  mkdir $PSYSH_DIR && wget $PHP_MANUAL_URL -P $PSYSH_DIR && \
+  mkdir $PSYSH_DIR && curl $PHP_MANUAL_URL -o $PSYSH_PHP_MANUAL && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
   composer config -g process-timeout 3600 && \
   composer config -g repos.packagist composer https://packagist.jp && \


### PR DESCRIPTION
## DL3018 Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`

https://github.com/hadolint/hadolint/wiki/DL3018

## DL4001 Either use Wget or Curl but not both

https://github.com/hadolint/hadolint/wiki/DL4001

## DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it

https://github.com/hadolint/hadolint/wiki/DL4006
