### PR TITLE
Delete apt cache for reduce container image size

### DIFF
--- a/infrastructure/docker/php/Dockerfile
+++ b/infrastructure/docker/php/Dockerfile
@@ -29,6 +29,8 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && \
   apt-get -y install git libicu-dev libonig-dev libzip-dev unzip locales && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
   locale-gen en_US.UTF-8 && \
   localedef -f UTF-8 -i en_US en_US.UTF-8 && \
   mkdir /var/run/php-fpm && \


### PR DESCRIPTION
clean up the apt cache.
It will reduces the container image size about 17M.