### PR TITLE
ログとキャッシュディレクトリのパーミッション変更

### DIFF
--- a/infrastructure/Makefile
+++ b/infrastructure/Makefile
@@ -8,6 +8,7 @@ create-project:
 	@make build
 	@make up
 	docker-compose exec app composer create-project --prefer-dist laravel/laravel .
+	docker-compose exec app chmod -R 777 storage/ bootstrap/cache/
 install-recommend-packages:
 	docker-compose exec app composer require doctrine/dbal
 	docker-compose exec app composer require --dev barryvdh/laravel-ide-helper


### PR DESCRIPTION
# 概要
Linux上でLaravelのプロジェクトを作成した際に、ログやキャッシュ関連のパーミッションが755になり、ログが書き込めずエラーになるようです。
（私の再現環境はWSL2上のUbuntu18.04です）

# 修正内容
Makefileのcreate-projecteオプションにて、プロジェクト作成後にchmodでパーミッションを777に変更。