### PR TITLE
fix #98

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ create-project:
 	docker-compose exec app php artisan storage:link
 	@make fresh
 install-recommend-packages:
-	docker-compose exec app composer require doctrine/dbal
+	docker-compose exec app composer require doctrine/dbal "^2"
 	docker-compose exec app composer require --dev barryvdh/laravel-ide-helper
 	docker-compose exec app composer require --dev beyondcode/laravel-dump-server
 	docker-compose exec app composer require --dev barryvdh/laravel-debugbar


### PR DESCRIPTION
Closes #98 

make install-recommend-packages が完了するようになります。
なお、composer.json はこのようになります

```diff

❯ git diff backend/composer.json
diff --git a/backend/composer.json b/backend/composer.json
index 2bc6bbe..26cf900 100644
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -9,6 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
+        "doctrine/dbal": "^2",
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
@@ -16,12 +17,16 @@
         "laravel/tinker": "^2.5"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^3.5",
+        "barryvdh/laravel-ide-helper": "^2.8",
+        "beyondcode/laravel-dump-server": "^1.7",
         "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^0.0.5",
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^5.0",
-        "phpunit/phpunit": "^9.3.3"
+        "phpunit/phpunit": "^9.3.3",
+        "roave/security-advisories": "dev-master"
     },
     "config": {
         "optimize-autoloader": true,

```