### PR TITLE
Minimize environment variable parameters in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -22,11 +22,6 @@ services:
         volume:
           nocopy: true
     environment:
-      - APP_DEBUG=${APP_DEBUG:-true}
-      - APP_ENV=${APP_ENV:-local}
-      - APP_URL=${APP_URL:-http://localhost}
-      - LOG_CHANNEL=${LOG_CHANNEL:-stderr}
-      - LOG_STDERR_FORMATTER=${LOG_STDERR_FORMATTER:-Monolog\Formatter\JsonFormatter}
       - DB_CONNECTION=${DB_CONNECTION:-mysql}
       - DB_HOST=${DB_HOST:-db}
       - DB_PORT=${DB_PORT:-3306}


### PR DESCRIPTION
Minimize environment variable parameters in compose.yml

## summary

- I don't want you to manage environment variables in compose.yml
- I saw someone having trouble changing the environment variables in compose.yml because they were stronger than the values in .env.
