### PR TITLE
Run the app container as a non-root user(nobody:nogroup)

### DIFF
--- a/.github/workflows/laravel-create-project.yaml
+++ b/.github/workflows/laravel-create-project.yaml
@@ -11,7 +11,10 @@ jobs:
       - name: Docker Version
         run: docker version
       - name: Docker Compose Settings
-        run: echo APP_BUILD_TARGET=development-xdebug > .env
+        run: |
+          echo APP_BUILD_TARGET=development-xdebug > .env
+          echo "UID=$(id -u)" >> .env
+          echo "GID=$(id -g)" >> .env
       - name: Build Docker Images
         run: docker compose build
       - name: Create & Start Docker Containers

--- a/.github/workflows/laravel-git-clone.yaml
+++ b/.github/workflows/laravel-git-clone.yaml
@@ -13,7 +13,10 @@ jobs:
       - name: Docker Version
         run: docker version
       - name: Docker Compose Settings
-        run: echo APP_BUILD_TARGET=development-xdebug > .env
+        run: |
+          echo APP_BUILD_TARGET=development-xdebug > .env
+          echo "UID=$(id -u)" >> .env
+          echo "GID=$(id -g)" >> .env
       - name: Build Docker Images
         run: docker compose build
       - name: Create & Start Docker Containers

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+for-linux-env:
+	echo "UID=$$(id -u)" >> .env
+	echo "GID=$$(id -g)" >> .env
 install:
 	@make build
 	@make up

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Introduction
 
-Build a simple laravel development environment with docker-compose. Compatible with Windows(WSL2), macOS(M1) and Linux.
+Build a simple laravel development environment with Docker Compose. Support with Windows(WSL2), macOS(Intel and Apple Silicon) and Linux.
 
 ## Usage
 
@@ -22,13 +22,18 @@ Build a simple laravel development environment with docker-compose. Compatible w
 3. Execute the following command
 
 ```bash
+$ task for-linux-env # Linux environment only
 $ task create-project
 
 # or...
 
+$ make for-linux-env # Linux environment only
 $ make create-project
 
 # or...
+
+$ echo "UID=$(id -u)" >> .env # Linux environment only
+$ echo "GID=$(id -g)" >> .env # Linux environment only
 
 $ mkdir -p src
 $ docker compose build
@@ -48,13 +53,18 @@ http://localhost
 2. Execute the following command
 
 ```bash
+$ task for-linux-env # Linux environment only
 $ task install
 
 # or...
 
+$ make for-linux-env # Linux environment only
 $ make install
 
 # or...
+
+$ echo "UID=$(id -u)" >> .env # Linux environment only
+$ echo "GID=$(id -g)" >> .env # Linux environment only
 
 $ docker compose build
 $ docker compose up -d

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,6 +1,11 @@
 version: '3'
 
 tasks:
+  for-linux-env:
+    cmds:
+      - echo "UID=$(id -u)" >> .env
+      - echo "GID=$(id -g)" >> .env
+
   install:
     cmds:
       - docker compose build

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,9 @@ services:
     build:
       context: .
       dockerfile: ./infra/docker/php/Dockerfile
+      args:
+        UID: ${UID:-65534}
+        GID: ${GID:-65534}
       target: ${APP_BUILD_TARGET:-development}
     volumes:
       - type: bind
@@ -18,7 +21,7 @@ services:
         target: /workspace
       - type: volume
         source: psysh-store
-        target: /root/.config/psysh
+        target: /nonexistent/.config/psysh
         volume:
           nocopy: true
     environment:

--- a/infra/docker/php/Dockerfile
+++ b/infra/docker/php/Dockerfile
@@ -9,8 +9,10 @@ ENV TZ=UTC \
   LANGUAGE=en_US:en \
   LC_ALL=en_US.UTF-8 \
   # composer environment
-  COMPOSER_ALLOW_SUPERUSER=1 \
   COMPOSER_HOME=/composer
+
+ARG UID=65534
+ARG GID=65534
 
 COPY --from=composer:2.7 /usr/bin/composer /usr/bin/composer
 
@@ -22,7 +24,8 @@ RUN <<EOF
     unzip \
     libzip-dev \
     libicu-dev \
-    libonig-dev
+    libonig-dev \
+    default-mysql-client
   locale-gen en_US.UTF-8
   localedef -f UTF-8 -i en_US en_US.UTF-8
   docker-php-ext-install \
@@ -30,40 +33,54 @@ RUN <<EOF
     pdo_mysql \
     zip \
     bcmath
-  composer config -g process-timeout 3600
-  composer config -g repos.packagist composer https://packagist.org
+  # permission denied bind mount in Linux environment
+  groupadd --gid $GID nogroup
+  useradd --uid $UID --gid $GID nobody
+  mkdir /composer
+  chown nobody:nogroup /composer
+  chown nobody:nogroup /workspace
 EOF
 
 FROM base AS development
 
 RUN <<EOF
-  apt-get -y install --no-install-recommends \
-    default-mysql-client
   apt-get clean
   rm -rf /var/lib/apt/lists/*
 EOF
 
 COPY ./infra/docker/php/php.development.ini /usr/local/etc/php/php.ini
 
-FROM development AS development-xdebug
+USER nobody
+
+FROM base AS development-xdebug
 
 RUN <<EOF
   pecl install xdebug
   docker-php-ext-enable xdebug
+  apt-get clean
+  rm -rf /var/lib/apt/lists/*
 EOF
 
 COPY ./infra/docker/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
+USER nobody
+
 FROM base AS deploy
 
 COPY ./infra/docker/php/php.deploy.ini /usr/local/etc/php/php.ini
-COPY ./src /workspace
+COPY --chown=nobody:nogroup ./src /workspace
 
 RUN <<EOF
-  composer install -q -n --no-ansi --no-dev --no-scripts --no-progress --prefer-dist
+  apt-get clean
+  rm -rf /var/lib/apt/lists/*
+EOF
+
+USER nobody
+
+RUN <<EOF
+  composer install --quiet --no-interaction --no-ansi --no-dev --no-scripts --no-progress --prefer-dist
+  composer dump-autoload --optimize
   chmod -R 777 storage bootstrap/cache
   php artisan optimize:clear
   php artisan optimize
-  apt-get clean
-  rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
## Problem

When a file system is bind mounted in a container, the uid and gid are used as they are between the host machine and the container, causing a problem where the owner of the file written by the container becomes the root user.

See #258

One possibility is to run Docker itself in [rootless mode](https://docs.docker.com/engine/security/rootless), but it also seems possible to assign non-root users the same UID and GID as Linux.

Run the container as `nobody:nogroup`, which is the opposite of the root user.

## Operation confirmation

```bash
$ task for-linux-env # Linux environment only
$ task create-project

# or...

$ make for-linux-env # Linux environment only
$ make create-project

# or...

$ echo "UID=$(id -u)" >> .env # Linux environment only
$ echo "GID=$(id -g)" >> .env # Linux environment only

$ mkdir -p src
$ docker compose build
$ docker compose up -d
$ docker compose exec app composer create-project --prefer-dist laravel/laravel .
$ docker compose exec app php artisan key:generate
$ docker compose exec app php artisan storage:link
$ docker compose exec app chmod -R 777 storage bootstrap/cache
$ docker compose exec app php artisan migrate
```

http://localhost

<!--

## Help

I'm currently not in a position to try it on Linux, so I'd like someone to review it.