### PR TITLE
Fix Laravel 11+ installation by updating default DB connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install:
 	@make up
 	docker compose exec app composer install
 	docker compose exec app cp .env.example .env
+	docker compose exec app sed  -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
 	docker compose exec app php artisan key:generate
 	docker compose exec app php artisan storage:link
 	docker compose exec app chmod -R 777 storage bootstrap/cache
@@ -15,6 +16,8 @@ create-project:
 	docker compose build
 	docker compose up -d
 	docker compose exec app composer create-project --prefer-dist laravel/laravel .
+	docker compose exec app cp .env.example .env
+	docker compose exec app sed  -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
 	docker compose exec app php artisan key:generate
 	docker compose exec app php artisan storage:link
 	docker compose exec app chmod -R 777 storage bootstrap/cache

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ mkdir -p src
 $ docker compose build
 $ docker compose up -d
 $ docker compose exec app composer create-project --prefer-dist laravel/laravel .
+$ docker compose exec app cp .env.example .env
+$ docker compose exec app sed  -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
 $ docker compose exec app php artisan key:generate
 $ docker compose exec app php artisan storage:link
 $ docker compose exec app chmod -R 777 storage bootstrap/cache
@@ -70,6 +72,7 @@ $ docker compose build
 $ docker compose up -d
 $ docker compose exec app composer install
 $ docker compose exec app cp .env.example .env
+$ docker compose exec app sed  -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
 $ docker compose exec app php artisan key:generate
 $ docker compose exec app php artisan storage:link
 $ docker compose exec app chmod -R 777 storage bootstrap/cache

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,6 +12,7 @@ tasks:
       - task: up
       - docker compose exec app composer install
       - docker compose exec app cp .env.example .env
+      - docker compose exec app sed  -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
       - docker compose exec app php artisan key:generate
       - docker compose exec app php artisan storage:link
       - docker compose exec app chmod -R 777 storage bootstrap/cache
@@ -23,6 +24,8 @@ tasks:
       - task: build
       - task: up
       - docker compose exec app composer create-project --prefer-dist laravel/laravel .
+      - docker compose exec app cp .env.example .env
+      - docker compose exec app sed  -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
       - docker compose exec app php artisan key:generate
       - docker compose exec app php artisan storage:link
       - docker compose exec app chmod -R 777 storage bootstrap/cache


### PR DESCRIPTION
Starting from Laravel 11, the default .env.example sets DB_CONNECTION=sqlite. This causes issues in this Docker setup which expects a MySQL database during installation. This PR changes the default DB connection back to MySQL to ensure compatibility and successful setup out of the box.



