### PR TITLE
Bump Composer version

### DIFF
--- a/infra/docker/php/Dockerfile
+++ b/infra/docker/php/Dockerfile
@@ -14,7 +14,7 @@ ENV TZ=UTC \
 ARG UID=1000
 ARG GID=1000
 
-COPY --from=composer:2.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.9 /usr/bin/composer /usr/bin/composer
 
 # hadolint ignore=DL3008
 RUN <<EOF


### PR DESCRIPTION
Bump Composer from version 2.7 to 2.9.

The current Composer version has security vulnerabilities.
