### PR TITLE
docs: document Docker BuildKit requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@
 
 Build a simple laravel development environment with Docker Compose. Support with Windows(WSL2), macOS(Intel and Apple Silicon) and Linux.
 
+## Requirements
+
+- **Docker Engine v23.0+ (BuildKit enabled by default) or the latest Docker Desktop**
+
+The Dockerfile uses [here-documents (`RUN <<EOF`)](https://docs.docker.com/reference/dockerfile/#here-documents), which require [BuildKit](https://docs.docker.com/build/buildkit/). When BuildKit is disabled (e.g. an old Docker version or the legacy builder), the `RUN` instructions are silently skipped, so required packages such as `git` are never installed. The build still succeeds, but `composer install` later fails with `git was not found in your PATH`.
+
+BuildKit is enabled by default on Docker Engine v23.0+ and Docker Desktop. If you must use an older Docker, enable it explicitly before building:
+
+```bash
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+```
+
 ## Usage
 
 ### Create an initial Laravel project


### PR DESCRIPTION
## Summary

Document the Docker BuildKit requirement in the README to prevent the issue reported in #284.

The `infra/docker/php/Dockerfile` uses here-document `RUN <<EOF` syntax, which is a BuildKit-only feature. When the image is built with the legacy builder (BuildKit disabled, typically an old Docker version), the `RUN` block is silently skipped — `apt-get install git unzip ...` never runs. The build still succeeds, but the resulting image has no `git`, so `composer install` during `make install` fails with:

```
git was not found in your PATH, skipping source download
```

## Changes

- Add a **Requirements** section to `README.md` describing:
  - Recommended Docker version: Docker Engine v23.0+ (BuildKit enabled by default) or the latest Docker Desktop
  - Why BuildKit is required (here-document `RUN` syntax)
  - How to enable BuildKit explicitly on older Docker (`DOCKER_BUILDKIT=1`, `COMPOSE_DOCKER_CLI_BUILD=1`)

## Test plan

- [ ] Documentation-only change; rendered Markdown reviewed
- [ ] Links to Docker BuildKit / here-documents docs resolve correctly

Closes #284
