### PR TITLE
docs: sync README container versions with Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,18 +108,18 @@ http://localhost
 ### app container
 
 - Base image
-  - [php](https://hub.docker.com/_/php):8.3-fpm-bullseye
-  - [composer](https://hub.docker.com/_/composer):2.7
+  - [php](https://hub.docker.com/_/php):8.4-fpm-bullseye
+  - [composer](https://hub.docker.com/_/composer):2.10
 
 ### web container
 
 - Base image
-  - [nginx](https://hub.docker.com/_/nginx):1.26
+  - [nginx](https://hub.docker.com/_/nginx):1.31
 
 ### db container
 
 - Base image
-  - [mysql](https://hub.docker.com/_/mysql):8.4
+  - [mysql](https://hub.docker.com/_/mysql):9.7
 
 ### mailpit container
 


### PR DESCRIPTION
## Summary

The **Container structures** section in `README.md` listed base image versions that had drifted from the actual Dockerfiles after Renovate bumps. This syncs the four versions to match `infra/docker/*/Dockerfile`.

| Image | Before | After |
| --- | --- | --- |
| php | `8.3-fpm-bullseye` | `8.4-fpm-bullseye` |
| composer | `2.7` | `2.10` |
| nginx | `1.26` | `1.31` |
| mysql | `8.4` | `9.7` |

Documentation only — no behavior change. Recurrence prevention (dropping versions / Renovate automation) is intentionally left out of scope for a follow-up.

## Test plan
- [x] Each README version string matches the corresponding `FROM` / `COPY --from=composer:` line in the Dockerfiles
- [x] `git diff` touches only the four version lines in `README.md`

Closes #295