### PR TITLE
feat: add FrankenPHP as an opt-in alternative stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,20 @@ pint:
 	docker compose exec app ./vendor/bin/pint --verbose
 pint-test:
 	docker compose exec app ./vendor/bin/pint --verbose --test
+build-frankenphp:
+	docker compose -f compose.yaml -f compose.frankenphp.yaml build
+up-frankenphp:
+	docker compose -f compose.yaml -f compose.frankenphp.yaml rm --stop --force web
+	docker compose -f compose.yaml -f compose.frankenphp.yaml up --detach --remove-orphans
+down-frankenphp:
+	docker compose -f compose.yaml -f compose.frankenphp.yaml down --remove-orphans
+install-frankenphp:
+	@make build-frankenphp
+	@make up-frankenphp
+	docker compose -f compose.yaml -f compose.frankenphp.yaml exec app composer install
+	docker compose -f compose.yaml -f compose.frankenphp.yaml exec app cp .env.example .env
+	docker compose -f compose.yaml -f compose.frankenphp.yaml exec app sed -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
+	docker compose -f compose.yaml -f compose.frankenphp.yaml exec app php artisan key:generate
+	docker compose -f compose.yaml -f compose.frankenphp.yaml exec app php artisan storage:link
+	docker compose -f compose.yaml -f compose.frankenphp.yaml exec app chmod -R 777 storage bootstrap/cache
+	docker compose -f compose.yaml -f compose.frankenphp.yaml exec app php artisan migrate --force

--- a/README.md
+++ b/README.md
@@ -91,6 +91,44 @@ $ docker compose exec app chmod -R 777 storage bootstrap/cache
 
 http://localhost
 
+## FrankenPHP (opt-in alternative stack)
+
+[FrankenPHP](https://frankenphp.dev/) is available as an opt-in alternative to the default `nginx` + `php-fpm` stack. The default stack is **unchanged**; FrankenPHP is activated only when you explicitly pass the overlay file.
+
+Key differences from the default stack:
+
+- A single `app` container replaces both `app` and `web` (FrankenPHP serves HTTP itself on port 80).
+- Runs in classic mode — file changes in `./src` are reflected immediately without rebuilding.
+- An `xdebug` build target (`development-xdebug`) is available via `APP_BUILD_TARGET`.
+- Run only one stack at a time — both bind port 80 and share the same Compose project. The `*-frankenphp` targets stop the default `web` container for you; if you start the overlay manually after the default stack, run `docker compose down` first.
+
+### Use FrankenPHP with an existing Laravel project
+
+```bash
+$ task install-frankenphp
+
+# or...
+
+$ make install-frankenphp
+
+# or... manually
+
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml build
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml rm --stop --force web
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml up --detach --remove-orphans
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml exec app composer install
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml exec app cp .env.example .env
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml exec app sed -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml exec app php artisan key:generate
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml exec app php artisan storage:link
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml exec app chmod -R 777 storage bootstrap/cache
+$ docker compose -f compose.yaml -f compose.frankenphp.yaml exec app php artisan migrate --force
+```
+
+On Linux, set your host UID/GID first so files generated in `./src` are owned by you. Run `task for-linux-env` (or append `UID=$(id -u)`, `GID=$(id -g)`, `USERNAME=$(whoami)` to `.env`) before the commands above; the FrankenPHP entrypoint reads these and falls back to `1000:1000` when they are unset.
+
+http://localhost
+
 ## Tips
 
 - Read this [Taskfile](https://github.com/ucan-lab/docker-laravel/blob/main/Taskfile.yml).
@@ -110,6 +148,7 @@ http://localhost
 - Base image
   - [php](https://hub.docker.com/_/php):8.4-fpm-bullseye
   - [composer](https://hub.docker.com/_/composer):2.10
+  - (FrankenPHP overlay) [dunglas/frankenphp](https://hub.docker.com/r/dunglas/frankenphp):1-php8.4
 
 ### web container
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,3 +159,28 @@ tasks:
   pint-test:
     cmds:
       - docker compose exec app ./vendor/bin/pint --verbose --test
+
+  build-frankenphp:
+    cmds:
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml build
+
+  up-frankenphp:
+    cmds:
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml rm --stop --force web
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml up --detach --remove-orphans
+
+  down-frankenphp:
+    cmds:
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml down --remove-orphans
+
+  install-frankenphp:
+    cmds:
+      - task: build-frankenphp
+      - task: up-frankenphp
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml exec app composer install
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml exec app cp .env.example .env
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml exec app sed -i 's/DB_CONNECTION=.*/DB_CONNECTION=mysql/' .env
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml exec app php artisan key:generate
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml exec app php artisan storage:link
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml exec app chmod -R 777 storage bootstrap/cache
+      - docker compose -f compose.yaml -f compose.frankenphp.yaml exec app php artisan migrate --force

--- a/compose.frankenphp.yaml
+++ b/compose.frankenphp.yaml
@@ -1,0 +1,19 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./infra/docker/php-frankenphp/Dockerfile
+    ports:
+      - target: 80
+        published: ${APP_PUBLISHED_PORT:-80}
+        protocol: tcp
+        mode: host
+    environment:
+      - UID=${UID:-1000}
+      - GID=${GID:-1000}
+      - USERNAME=${USERNAME:-phper}
+
+  # nginx is unused in the FrankenPHP overlay; FrankenPHP serves HTTP itself.
+  web:
+    profiles:
+      - donotstart

--- a/compose.frankenphp.yaml
+++ b/compose.frankenphp.yaml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./infra/docker/php-frankenphp/Dockerfile
     ports:
       - target: 80
-        published: ${APP_PUBLISHED_PORT:-80}
+        published: ${WEB_PUBLISHED_PORT:-80}
         protocol: tcp
         mode: host
     environment:

--- a/infra/docker/php-frankenphp/Dockerfile
+++ b/infra/docker/php-frankenphp/Dockerfile
@@ -1,0 +1,63 @@
+FROM dunglas/frankenphp:1-php8.4 AS base
+
+WORKDIR /workspace
+
+# timezone / locale / composer / FrankenPHP HTTP-only in dev
+ENV TZ=UTC \
+  LANG=en_US.UTF-8 \
+  LANGUAGE=en_US:en \
+  LC_ALL=en_US.UTF-8 \
+  COMPOSER_HOME=/composer \
+  SERVER_NAME=:80
+
+COPY --from=composer:2.10 /usr/bin/composer /usr/bin/composer
+
+# hadolint ignore=DL3008
+RUN <<EOF
+  apt-get update
+  apt-get -y install --no-install-recommends \
+    locales \
+    git \
+    unzip \
+    default-mysql-client \
+    gosu
+  locale-gen en_US.UTF-8
+  localedef -f UTF-8 -i en_US en_US.UTF-8
+  install-php-extensions \
+    intl \
+    pdo_mysql \
+    zip \
+    bcmath \
+    opcache
+  mkdir /composer
+  apt-get clean
+  rm -rf /var/lib/apt/lists/*
+EOF
+
+COPY --chmod=755 ./infra/docker/php-frankenphp/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile"]
+
+FROM base AS development
+
+COPY ./infra/docker/php/php.development.ini /usr/local/etc/php/php.ini
+
+FROM development AS development-xdebug
+
+RUN install-php-extensions xdebug
+
+COPY ./infra/docker/php/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+
+FROM base AS deploy
+
+COPY ./infra/docker/php/php.deploy.ini /usr/local/etc/php/php.ini
+COPY ./src /workspace
+
+RUN <<EOF
+  composer install --quiet --no-interaction --no-ansi --no-dev --no-scripts --no-progress --prefer-dist
+  composer dump-autoload --optimize
+  chmod -R 777 storage bootstrap/cache
+  php artisan optimize:clear
+  php artisan optimize
+EOF

--- a/infra/docker/php-frankenphp/entrypoint.sh
+++ b/infra/docker/php-frankenphp/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+UID=${UID:-1000}
+GID=${GID:-1000}
+USERNAME=${USERNAME:-phper}
+
+echo "Starting with UID: $UID, GID: $GID, USERNAME: $USERNAME"
+
+if ! id "$USERNAME" >/dev/null 2>&1; then
+  useradd -u "$UID" -o -m "$USERNAME"
+fi
+# Align the primary group GID when possible; ignore when the GID already exists
+# (e.g. a host GID that collides with a system group, common on macOS).
+groupmod -g "$GID" "$USERNAME" 2>/dev/null || true
+
+mkdir -p /home/"$USERNAME"/.config/psysh
+chown -R "$USERNAME":"$USERNAME" /home/"$USERNAME"
+chown "$USERNAME":"$USERNAME" /composer
+chown "$USERNAME":"$USERNAME" /workspace
+# FrankenPHP (Caddy) writable state dirs
+chown -R "$USERNAME":"$USERNAME" /data /config 2>/dev/null || true
+
+export HOME=/home/"$USERNAME"
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+  set -- frankenphp run --config /etc/frankenphp/Caddyfile "$@"
+fi
+
+exec gosu "$USERNAME" "$@"


### PR DESCRIPTION
## Summary

Adds **FrankenPHP** (Caddy-based PHP app server) as an **opt-in alternative** to the default `nginx` + `php-fpm` stack, selectable via a Compose overlay. The default stack is **unchanged** — `compose.yaml` and the existing `infra/docker/php/*` files are untouched, so existing users are not affected.

Runs in **classic mode** (file changes in `./src` reflected immediately, matching the current dev experience). Octane / worker mode is intentionally deferred to a future issue.

closes #249

## What's included

- `infra/docker/php-frankenphp/Dockerfile` — multi-stage build (`base` / `development` / `development-xdebug` / `deploy`) based on `dunglas/frankenphp:1-php8.4` (Debian). Extensions via `install-php-extensions intl pdo_mysql zip bcmath opcache` (+`xdebug` on the debug target). `SERVER_NAME=:80` pins HTTP-only in dev (no auto-TLS); the default FrankenPHP Caddyfile serves `/workspace/public`, so no custom Caddyfile is needed. Reuses the existing `infra/docker/php/*.ini` files.
- `infra/docker/php-frankenphp/entrypoint.sh` — ports the `useradd` / `gosu` UID/GID approach from the existing entrypoint, hardened with defaults so it also boots standalone (macOS). FrankenPHP runs **non-root**; binding `:80` works thanks to the `cap_net_bind_service` capability on the `frankenphp` binary.
- `compose.frankenphp.yaml` — overlay that swaps `app` to the FrankenPHP build and publishes port 80. The nginx `web` service is excluded via an inactive `donotstart` profile so it does not also bind `:80`.
- `Makefile` / `Taskfile.yml` — `build-frankenphp`, `up-frankenphp`, `down-frankenphp`, `install-frankenphp` targets. `up-frankenphp` first stops/removes a running default `web` container so switching stacks does not clash on port 80.
- `README.md` — documents opt-in usage, the single-stack-at-a-time constraint, and the Linux UID/GID setup.

## Usage

```bash
task install-frankenphp        # or: make install-frankenphp
# then open http://localhost
```

## Test plan (verified live on Docker 29.4 / Compose v5.1, Apple Silicon)

- `docker compose -f compose.yaml -f compose.frankenphp.yaml build` succeeds; `development-xdebug` and `deploy` targets also build (clean build).
- Overlay boots: FrankenPHP starts non-root and serves on `:80`; `curl http://localhost` returns **HTTP 200** with the Laravel welcome page.
- DB connection works: `php artisan migrate` succeeds against the `db` service (`mysql@db:3306`).
- **Non-breaking**: the default `docker compose build` + `up` still works and serves Laravel via nginx + php-fpm with a working DB connection.
- Stack switch: starting `up-frankenphp` while the default `web` is running removes `web` and brings up FrankenPHP on `:80` without a port clash.

## Notes / trade-offs

- Maintaining two stacks slightly increases the Renovate/update surface (the new `dunglas/frankenphp` image tag).
- Production/worker mode (Octane) is out of scope and deferred.